### PR TITLE
!HOTFIX: 리펙토링 시 삭제하지 않은 코드 제거

### DIFF
--- a/src/main/java/nbc/chillguys/nebulazone/application/products/dto/response/CreateProductResponse.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/products/dto/response/CreateProductResponse.java
@@ -23,7 +23,6 @@ public record CreateProductResponse(
 			.description(product.getDescription())
 			.price(product.getPrice())
 			.txMethod(product.getTxMethod())
-			.endTime(product.getEndTime())
 			.modifiedAt(product.getModifiedAt())
 			.build();
 	}


### PR DESCRIPTION
Product 엔티티에서 endTime 필드를 제거했는데 DTO에서 제거하지 않아서 해당 필드를 제거