### PR TITLE
Feat: 유저 조회, 수정, 탈퇴, 로그아웃

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
 
     // queryDSL
-    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
+    //  "cannot find symbol: annotation Entity" 또는 "package jakarta.annotation does not exist" 오류 발생시 주석 풀고 추가
+//    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+//    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/nbc/chillguys/nebulazone/application/auth/controller/AuthController.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/auth/controller/AuthController.java
@@ -26,4 +26,11 @@ public class AuthController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@PostMapping("/signout")
+	public ResponseEntity<String> signOut() {
+		authService.signOut();
+
+		return ResponseEntity.ok("로그아웃 성공");
+	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/application/auth/service/AuthService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package nbc.chillguys.nebulazone.application.auth.service;
 
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import nbc.chillguys.nebulazone.application.auth.dto.request.SignInRequest;
@@ -12,6 +14,7 @@ import nbc.chillguys.nebulazone.infra.security.jwt.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
 	private final UserDomainService userDomainService;
 	private final JwtUtil jwtUtil;
@@ -27,5 +30,9 @@ public class AuthService {
 		String refreshToken = jwtUtil.generateRefreshToken(authUser);
 
 		return SignInResponse.of(accessToken, refreshToken);
+	}
+
+	public void signOut() {
+		SecurityContextHolder.clearContext();
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/controller/UserController.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/controller/UserController.java
@@ -77,7 +77,7 @@ public class UserController {
 	@PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<UserResponse> updateUser(
 		@Valid @RequestPart(value = "updateUserRequest", required = false) UpdateUserRequest updateUserRequest,
-		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+		@ImageFile @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
 		UserResponse response = userService.updateUser(updateUserRequest, profileImage, authUser);

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/controller/UserController.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/controller/UserController.java
@@ -3,7 +3,13 @@ package nbc.chillguys.nebulazone.application.user.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,12 +18,14 @@ import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import nbc.chillguys.nebulazone.application.user.dto.request.SignUpUserRequest;
+import nbc.chillguys.nebulazone.application.user.dto.request.UpdateUserRequest;
+import nbc.chillguys.nebulazone.application.user.dto.request.WithdrawUserRequest;
 import nbc.chillguys.nebulazone.application.user.dto.response.UserResponse;
 import nbc.chillguys.nebulazone.application.user.service.UserService;
+import nbc.chillguys.nebulazone.domain.auth.vo.AuthUser;
 import nbc.chillguys.nebulazone.domain.common.validator.image.ImageFile;
 
 @RestController
@@ -28,7 +36,7 @@ public class UserController {
 
 	@Operation(
 		summary = "회원가입",
-		requestBody = @RequestBody(
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
 			content = @Content(
 				mediaType = "multipart/form-data",
 				encoding = {
@@ -46,5 +54,44 @@ public class UserController {
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(responseDto);
+	}
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<UserResponse> getUser(@PathVariable("userId") Long userId) {
+		UserResponse response = userService.getUser(userId);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(
+		summary = "유저수정",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			content = @Content(
+				mediaType = "multipart/form-data",
+				encoding = {
+					@Encoding(name = "updateUserRequest", contentType = "application/json")
+				}
+			)
+		)
+	)
+	@PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<UserResponse> updateUser(
+		@Valid @RequestPart(value = "updateUserRequest", required = false) UpdateUserRequest updateUserRequest,
+		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		UserResponse response = userService.updateUser(updateUserRequest, profileImage, authUser);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Long> withdrawUser(
+		@Valid @RequestBody WithdrawUserRequest withdrawUserRequest,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		Long withdrawnUserId = userService.withdrawUser(withdrawUserRequest, authUser);
+
+		return ResponseEntity.ok(withdrawnUserId);
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,25 @@
+package nbc.chillguys.nebulazone.application.user.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateUserRequest(
+	String nickname,
+
+	@Valid
+	PasswordChangeForm passwordChangeForm
+) {
+	public record PasswordChangeForm(
+		@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+		@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[\\]}:;\"'<,>.?/])\\S{8,}$",
+			message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함하며 8글자 이상이어야 합니다.")
+		String oldPassword,
+
+		@NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+		@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[\\]}:;\"'<,>.?/])\\S{8,}$",
+			message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함하며 8글자 이상이어야 합니다.")
+		String newPassword
+	) {
+	}
+}

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/WithdrawUserRequest.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/WithdrawUserRequest.java
@@ -1,0 +1,12 @@
+package nbc.chillguys.nebulazone.application.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record WithdrawUserRequest(
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[\\]}:;\"'<,>.?/])\\S{8,}$",
+		message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함하며 8글자 이상이어야 합니다.")
+	String oldPassword
+) {
+}

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/WithdrawUserRequest.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/dto/request/WithdrawUserRequest.java
@@ -7,6 +7,6 @@ public record WithdrawUserRequest(
 	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
 	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[\\]}:;\"'<,>.?/])\\S{8,}$",
 		message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함하며 8글자 이상이어야 합니다.")
-	String oldPassword
+	String password
 ) {
 }

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/service/UserService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService {
 	public Long withdrawUser(WithdrawUserRequest withdrawUserRequest, AuthUser authUser) {
 		User user = userDomainService.findActiveUserById(authUser.getId());
 
-		userDomainService.validPassword(withdrawUserRequest.oldPassword(), user.getPassword());
+		userDomainService.validPassword(withdrawUserRequest.password(), user.getPassword());
 
 		userDomainService.withdrawUser(user);
 

--- a/src/main/java/nbc/chillguys/nebulazone/application/user/service/UserService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/user/service/UserService.java
@@ -7,15 +7,21 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.chillguys.nebulazone.application.user.dto.request.SignUpUserRequest;
+import nbc.chillguys.nebulazone.application.user.dto.request.UpdateUserRequest;
+import nbc.chillguys.nebulazone.application.user.dto.request.WithdrawUserRequest;
 import nbc.chillguys.nebulazone.application.user.dto.response.UserResponse;
+import nbc.chillguys.nebulazone.domain.auth.vo.AuthUser;
 import nbc.chillguys.nebulazone.domain.user.dto.UserSignUpCommand;
 import nbc.chillguys.nebulazone.domain.user.entity.User;
+import nbc.chillguys.nebulazone.domain.user.exception.UserErrorCode;
+import nbc.chillguys.nebulazone.domain.user.exception.UserException;
 import nbc.chillguys.nebulazone.domain.user.service.UserDomainService;
 import nbc.chillguys.nebulazone.infra.aws.s3.S3Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 	private final UserDomainService userDomainService;
 	private final S3Service s3Service;
@@ -31,5 +37,57 @@ public class UserService {
 		User user = userDomainService.createUser(UserSignUpCommand.of(signUpUserRequest, profileImageUrl));
 
 		return UserResponse.from(user);
+	}
+
+	public UserResponse getUser(Long userId) {
+		User targetUser = userDomainService.findActiveUserById(userId);
+
+		return UserResponse.from(targetUser);
+	}
+
+	@Transactional
+	public UserResponse updateUser(UpdateUserRequest updateUserRequest, MultipartFile profileImage, AuthUser authUser) {
+		boolean noNickname = updateUserRequest.nickname() == null;
+		boolean noPassword = updateUserRequest.passwordChangeForm() == null;
+		boolean noImage = (profileImage == null || profileImage.isEmpty());
+
+		if (noNickname && noPassword && noImage) {
+			throw new UserException(UserErrorCode.NOTHING_TO_UPDATE);
+		}
+
+		User user = userDomainService.findActiveUserById(authUser.getId());
+
+		if (!noNickname) {
+			userDomainService.validNickname(updateUserRequest.nickname());
+
+			userDomainService.updateUserNickname(updateUserRequest.nickname(), user);
+		}
+
+		if (!noPassword) {
+			userDomainService.validPassword(updateUserRequest.passwordChangeForm().oldPassword(), user.getPassword());
+
+			userDomainService.updateUserPassword(updateUserRequest.passwordChangeForm().newPassword(), user);
+		}
+
+		if (!noImage) {
+			s3Service.generateDeleteUrlAndDeleteFile(user.getProfileImage());
+
+			String profileImageUrl = s3Service.generateUploadUrlAndUploadFile(profileImage);
+
+			userDomainService.updateUserProfileImage(profileImageUrl, user);
+		}
+
+		return UserResponse.from(user);
+	}
+
+	@Transactional
+	public Long withdrawUser(WithdrawUserRequest withdrawUserRequest, AuthUser authUser) {
+		User user = userDomainService.findActiveUserById(authUser.getId());
+
+		userDomainService.validPassword(withdrawUserRequest.oldPassword(), user.getPassword());
+
+		userDomainService.withdrawUser(user);
+
+		return user.getId();
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/domain/user/entity/User.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/user/entity/User.java
@@ -95,16 +95,21 @@ public class User extends BaseEntity {
 		this.roles.add(role);
 	}
 
-	public void addAddress(String roadAddress, String detailAddress) {
-		this.addresses.add(Address.builder()
-			.roadAddress(roadAddress)
-			.detailAddress(detailAddress)
-			.build());
-	}
-
-	public void delete() {
+	public void withdraw() {
 		this.status = UserStatus.INACTIVE;
 		this.deletedAt = LocalDateTime.now();
+	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public void updateProfileImage(String profileImage) {
+		this.profileImage = profileImage;
+	}
+
+	public void updatePassword(String password) {
+		this.password = password;
 	}
 }
 

--- a/src/main/java/nbc/chillguys/nebulazone/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,9 @@ import nbc.chillguys.nebulazone.common.exception.ErrorCode;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
+	NOTHING_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다."),
 	WRONG_ROLES(HttpStatus.BAD_REQUEST, "유저 권한을 잘못 입력하였습니다."),
+	SAME_PASSWORD(HttpStatus.BAD_REQUEST, "동일한 비밀번호로 변경할 수 없습니다."),
 	WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
 	ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일이 있습니다."),

--- a/src/main/java/nbc/chillguys/nebulazone/domain/user/service/UserDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/user/service/UserDomainService.java
@@ -38,6 +38,7 @@ public class UserDomainService {
 	 * @param rawPassword 원본 비밀번호
 	 * @param encodedPassword 암호화된 비밀번호
 	 * @throws UserException 일치 하지 않을 시 예외 발생
+	 * @author 이승현
 	 */
 	public void validPassword(String rawPassword, String encodedPassword) {
 		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
@@ -85,6 +86,7 @@ public class UserDomainService {
 	 * 이메일 검증
 	 * @param email 이메일
 	 * @throws UserException 중복된 이메일이 존재할 시 예외 발생
+	 * @author 이승현
 	 */
 	public void validEmail(String email) {
 		if (userRepository.existsByEmail(email)) {
@@ -96,10 +98,64 @@ public class UserDomainService {
 	 * 닉네임 검증
 	 * @param nickname 닉네임
 	 * @throws UserException 중복된 닉네임 존재할 시 예외 발생
+	 * @author 이승현
 	 */
 	public void validNickname(String nickname) {
 		if (userRepository.existsByNickname(nickname)) {
 			throw new UserException(UserErrorCode.ALREADY_EXISTS_NICKNAME);
 		}
+	}
+
+	/**
+	 * 닉네임 수정
+	 * @param nickname 닉네임
+	 * @param user 유저
+	 * @author 이승현
+	 */
+	public void updateUserNickname(String nickname, User user) {
+		user.updateNickname(nickname);
+	}
+
+	/**
+	 * 비밀번호 수정
+	 * @param newPassword 새 비밀번호
+	 * @param user 유저
+	 * @author 이승현
+	 */
+	public void updateUserPassword(String newPassword, User user) {
+		validNewPassword(newPassword, user.getPassword());
+
+		user.updatePassword(passwordEncoder.encode(newPassword));
+	}
+
+	/**
+	 * 프로필 이미지 수정
+	 * @param profileImageUrl 프로필 이미지 url
+	 * @param user 유저
+	 * @author 이승현
+	 */
+	public void updateUserProfileImage(String profileImageUrl, User user) {
+		user.updateProfileImage(profileImageUrl);
+	}
+
+	/**
+	 * 새 비밀번호 검증
+	 * @param newPassword 새 비밀번호
+	 * @param encodedPassword 암호화된 비밀번호
+	 * @author 이승현
+	 */
+	public void validNewPassword(String newPassword, String encodedPassword) {
+		if (passwordEncoder.matches(newPassword, encodedPassword)) {
+			throw new UserException(UserErrorCode.SAME_PASSWORD);
+		}
+	}
+
+	/**
+	 * 회원 탈퇴
+	 * @param user 유저
+	 * @author 이승현
+	 */
+	public void withdrawUser(User user) {
+		user.withdraw();
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/infra/aws/s3/S3Service.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/aws/s3/S3Service.java
@@ -15,8 +15,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.DeleteObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -39,16 +41,48 @@ public class S3Service {
 
 		String contentType = file.getContentType();
 
-		String presignedUrl = generateUploadUrl(fileName, contentType, file.getSize());
+		String presignedUploadUrl = generateUploadUrl(fileName, contentType, file.getSize());
 
-		if (!uploadFile(file, presignedUrl, contentType)) {
+		if (!uploadFile(file, presignedUploadUrl, contentType)) {
 			return null;
 		}
 
-		return presignedUrl.split("\\?")[0];
+		return presignedUploadUrl.split("\\?")[0];
 	}
 
-	public String generateUploadUrl(String fileName, String contentType, long contentLength) {
+	public void generateDeleteUrlAndDeleteFile(String presignedUrl) {
+		String presignedDeleteUrl = generateDeleteUrl(presignedUrl);
+
+		deleteFile(presignedDeleteUrl);
+	}
+
+	private String generateDeleteUrl(String presignedUrl) {
+		DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+			.bucket(bucket)
+			.key(presignedUrl.substring(presignedUrl.lastIndexOf("/") + 1))
+			.build();
+
+		DeleteObjectPresignRequest deleteObjectPresignRequest = DeleteObjectPresignRequest.builder()
+			.signatureDuration(Duration.ofMinutes(10))
+			.deleteObjectRequest(deleteObjectRequest)
+			.build();
+
+		return s3Presigner.presignDeleteObject(deleteObjectPresignRequest).url().toString();
+	}
+
+	private void deleteFile(String presignedUrl) {
+		ResponseEntity<String> response = restClient
+			.delete()
+			.uri(URI.create(presignedUrl))
+			.retrieve()
+			.toEntity(String.class);
+
+		if (!response.getStatusCode().is2xxSuccessful()) {
+			log.error("S3 파일 삭제 실패: {}, body: {}", response.getStatusCode(), response.getBody());
+		}
+	}
+
+	private String generateUploadUrl(String fileName, String contentType, long contentLength) {
 		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
 			.bucket(bucket)
 			.key(fileName)


### PR DESCRIPTION
- 유저 조회는 public, private를 나누지 않았습니다
- 수정은 닉네임, 비밀번호, 프로필 이미지 따로 따로 수정 가능(PATCH)
- 회원 탈퇴는 비밀번호 체크를 한 후 진행
- 로그아웃은 SecurityContextHolder만 비워주고 있는데 blackList 추가 고려 가능 -> 의견 남겨주세요!