### PR TITLE
HotFix: 어드민 키워드 검색 discription삭제

### DIFF
--- a/src/main/java/nbc/chillguys/nebulazone/domain/product/repository/ProductAdminRepositoryCustomImpl.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/product/repository/ProductAdminRepositoryCustomImpl.java
@@ -29,8 +29,7 @@ public class ProductAdminRepositoryCustomImpl implements ProductAdminRepositoryC
 
 		// 키워드 검색 (이름/설명)
 		if (command.keyword() != null && !command.keyword().isBlank()) {
-			builder.and(product.name.containsIgnoreCase(command.keyword())
-				.or(product.description.containsIgnoreCase(command.keyword())));
+			builder.and(product.name.containsIgnoreCase(command.keyword()));
 		}
 
 		// 거래방식(ProductTxMethod) 필터


### PR DESCRIPTION
mysql 에서 검색할 때 CLOB/LONGTEXT는 PQL LOWER/LTRIM/LIKE 등 함수 조합이 내부적으로 발생,
이 때 CLOB에 lower()가 먹히지 않아서 에러가 발생
discription을 키워드 검색에서 제거