### PR TITLE
Feat: 커스텀 필터와 AOP로 로그 남기기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,13 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
     // LocalDateTime 직렬화
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // ES
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/nbc/chillguys/nebulazone/infra/aop/LoggingAspect.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/aop/LoggingAspect.java
@@ -1,0 +1,62 @@
+package nbc.chillguys.nebulazone.infra.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import nbc.chillguys.nebulazone.domain.auth.vo.AuthUser;
+
+@Aspect
+@Slf4j
+@Component
+public class LoggingAspect {
+
+	@Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+	public void restController() {
+	}
+
+	@Before("restController()")
+	public void logRequestInfo(JoinPoint joinPoint) {
+		ServletRequestAttributes attr = (ServletRequestAttributes)RequestContextHolder.getRequestAttributes();
+		if (attr == null) {
+			return;
+		}
+		HttpServletRequest request = attr.getRequest();
+
+		String method = request.getMethod();
+		String uri = request.getRequestURI();
+
+		// 컨트롤러/메서드 정보
+		String className = joinPoint.getSignature().getDeclaringTypeName();
+		String methodName = joinPoint.getSignature().getName();
+
+		// 유저 정보
+		String userInfo = getUserInfo();
+
+		log.warn("[API 요청] {} | Controller={}.{} | 유저={}",
+			method, className, methodName, userInfo);
+	}
+
+	private String getUserInfo() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.isAuthenticated()
+			&& !"anonymousUser".equals(authentication.getPrincipal())) {
+			Object principal = authentication.getPrincipal();
+			if (principal instanceof AuthUser authUser) {
+				return String.format("id=%d, email=%s", authUser.getId(), authUser.getEmail());
+			} else if (principal instanceof org.springframework.security.core.userdetails.UserDetails userDetails) {
+				return userDetails.getUsername();
+			}
+			return principal.toString();
+		}
+		return "비회원";
+	}
+}

--- a/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import nbc.chillguys.nebulazone.infra.oauth.handler.OAuth2SuccessHandler;
 import nbc.chillguys.nebulazone.infra.oauth.service.OAuthService;
 import nbc.chillguys.nebulazone.infra.security.JwtUtil;
 import nbc.chillguys.nebulazone.infra.security.filter.CustomAuthenticationEntryPoint;
+import nbc.chillguys.nebulazone.infra.security.filter.ExceptionLoggingFilter;
 import nbc.chillguys.nebulazone.infra.security.filter.JwtAuthenticationFilter;
 
 @Configuration
@@ -84,6 +85,7 @@ public class SecurityConfig {
 				.successHandler(oAuth2SuccessHandler))
 			.exceptionHandling(exception ->
 				exception.authenticationEntryPoint(entryPoint))
+			.addFilterBefore(new ExceptionLoggingFilter(), UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}

--- a/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final OAuthService oAuthService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
+	private final ExceptionLoggingFilter exceptionLoggingFilter;
 
 	public SecurityConfig(ObjectMapper objectMapper, JwtUtil jwtUtil, OAuthService oAuthService,
 		OAuth2SuccessHandler oAuth2SuccessHandler) {
@@ -40,6 +41,7 @@ public class SecurityConfig {
 		this.jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtUtil, entryPoint);
 		this.oAuthService = oAuthService;
 		this.oAuth2SuccessHandler = oAuth2SuccessHandler;
+		this.exceptionLoggingFilter = new ExceptionLoggingFilter();
 	}
 
 	@Bean
@@ -85,7 +87,7 @@ public class SecurityConfig {
 				.successHandler(oAuth2SuccessHandler))
 			.exceptionHandling(exception ->
 				exception.authenticationEntryPoint(entryPoint))
-			.addFilterBefore(new ExceptionLoggingFilter(), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(exceptionLoggingFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}

--- a/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/security/config/SecurityConfig.java
@@ -36,12 +36,12 @@ public class SecurityConfig {
 	private final ExceptionLoggingFilter exceptionLoggingFilter;
 
 	public SecurityConfig(ObjectMapper objectMapper, JwtUtil jwtUtil, OAuthService oAuthService,
-		OAuth2SuccessHandler oAuth2SuccessHandler) {
+		OAuth2SuccessHandler oAuth2SuccessHandler, ExceptionLoggingFilter exceptionLoggingFilter) {
 		this.entryPoint = new CustomAuthenticationEntryPoint(objectMapper);
 		this.jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtUtil, entryPoint);
 		this.oAuthService = oAuthService;
 		this.oAuth2SuccessHandler = oAuth2SuccessHandler;
-		this.exceptionLoggingFilter = new ExceptionLoggingFilter();
+		this.exceptionLoggingFilter = exceptionLoggingFilter;
 	}
 
 	@Bean

--- a/src/main/java/nbc/chillguys/nebulazone/infra/security/filter/ExceptionLoggingFilter.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/security/filter/ExceptionLoggingFilter.java
@@ -1,0 +1,74 @@
+package nbc.chillguys.nebulazone.infra.security.filter;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+
+public class ExceptionLoggingFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(ExceptionLoggingFilter.class);
+	private static final Set<String> EXCLUDED_PATHS = Set.of(
+		"/actuator/prometheus", "/actuator/health", "/actuator/info"
+	);
+
+	@Override
+	protected void doFilterInternal(
+		@NonNull HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain)
+		throws ServletException, IOException {
+		String uri = request.getRequestURI();
+
+		if (EXCLUDED_PATHS.stream().anyMatch(uri::startsWith)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String ip = getClientIP(request);
+		String method = request.getMethod();
+		String traceId = java.util.UUID.randomUUID().toString().replace("-", "");
+
+		MDC.put("ip", ip);
+		MDC.put("uri", uri);
+		MDC.put("method", method);
+		MDC.put("traceId", traceId);
+
+		log.warn("[REQUEST] {} {} | IP={} | traceId={}", method, uri, ip, traceId);
+
+		try {
+			filterChain.doFilter(request, response);
+		} catch (Exception e) {
+			// 인증/인가/비즈니스 등 모든 예외 잡아서 로그로 남김
+			log.error("[FILTER ERROR] {} {} | IP={} | traceId={} | message={}",
+				method, uri, ip, traceId, e.getMessage(), e);
+			throw e; // 꼭 다시 던져야 ExceptionHandler에서 처리됨
+		} finally {
+			// (옵션) 응답 로그
+			log.warn("[RESPONSE] {} {} | status={} | IP={} | traceId={}", method, uri, response.getStatus(), ip,
+				traceId);
+			// MDC 초기화 (메모리릭 방지)
+			MDC.clear();
+		}
+	}
+
+	private String getClientIP(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getRemoteAddr();
+		}
+		if (ip != null && ip.contains(",")) {
+			ip = ip.split(",")[0];
+		}
+		return ip;
+	}
+}

--- a/src/main/java/nbc/chillguys/nebulazone/infra/security/filter/ExceptionLoggingFilter.java
+++ b/src/main/java/nbc/chillguys/nebulazone/infra/security/filter/ExceptionLoggingFilter.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 
+@Component
 public class ExceptionLoggingFilter extends OncePerRequestFilter {
 
 	private static final Logger log = LoggerFactory.getLogger(ExceptionLoggingFilter.class);


### PR DESCRIPTION
커스텀 필터와 AOP로 로그 남기기

예시 : 
- 커스텀 필터(ExceptionLoggingFilter)에서 모든 요청/응답/에러를 아래 형식으로 기록
  - [REQUEST] POST /api/xxx | IP=xxx.xxx.xxx.xxx | traceId=...
  - [RESPONSE] POST /api/xxx | status=200 | IP=xxx.xxx.xxx.xxx | traceId=...

- 비즈니스 AOP(LoggingAspect)에서 RestController 진입 시 아래 형식으로 기록
  - [API 요청] POST /api/xxx | Controller=패키지.클래스.메서드 | 유저=이메일

- 시스템/모니터링 경로(actuator 등)는 필요시 EXCLUDED_PATHS로 필터링 가능

최종 예시 :
- 2025-06-17 19:25:10.557 n.c.n.i.s.f.ExceptionLoggingFilter : [REQUEST] POST /auth/signin | IP=0:0:0:0:0:0:0:1 | traceId=xxxx
- 2025-06-17 19:25:10.621 n.c.n.i.a.LoggingAspect : [API 요청] POST /auth/signin | Controller=nbc.chillguys.nebulazone.application.auth.controller.AuthController.signIn | 유저=비회원 | IP=0:0:0:0:0:0:0:1
- 2025-06-17 19:25:10.741 n.c.n.i.s.f.ExceptionLoggingFilter : [RESPONSE] POST /auth/signin | status=200 | IP=0:0:0:0:0:0:0:1 | traceId=xxxx