### PR TITLE
Refactor: ES 관련 처리들 비동기로 수정(자동낙찰/수동낙찰 제외)

### DIFF
--- a/src/main/java/nbc/chillguys/nebulazone/application/post/service/PostService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/post/service/PostService.java
@@ -22,6 +22,7 @@ import nbc.chillguys.nebulazone.domain.post.dto.PostSearchCommand;
 import nbc.chillguys.nebulazone.domain.post.dto.PostUpdateCommand;
 import nbc.chillguys.nebulazone.domain.post.entity.Post;
 import nbc.chillguys.nebulazone.domain.post.entity.PostType;
+import nbc.chillguys.nebulazone.domain.post.event.CreatePostEvent;
 import nbc.chillguys.nebulazone.domain.post.event.DeletePostEvent;
 import nbc.chillguys.nebulazone.domain.post.event.UpdatePostEvent;
 import nbc.chillguys.nebulazone.domain.post.service.PostDomainService;
@@ -43,7 +44,7 @@ public class PostService {
 
 		Post createdPost = postDomainService.createPost(postCreateDto);
 
-		postDomainService.savePostToEs(createdPost);
+		eventPublisher.publishEvent(new CreatePostEvent(createdPost));
 
 		return CreatePostResponse.from(createdPost);
 
@@ -109,7 +110,7 @@ public class PostService {
 
 		Post updatedPost = postDomainService.updatePostImages(post, postImageUrls, user.getId());
 
-		postDomainService.savePostToEs(updatedPost);
+		eventPublisher.publishEvent(new UpdatePostEvent(updatedPost));
 
 		return GetPostResponse.from(updatedPost);
 	}

--- a/src/main/java/nbc/chillguys/nebulazone/application/product/listener/ProductCreatedEventListener.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/product/listener/ProductCreatedEventListener.java
@@ -1,0 +1,23 @@
+package nbc.chillguys.nebulazone.application.product.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import nbc.chillguys.nebulazone.domain.product.event.ProductCreatedEvent;
+import nbc.chillguys.nebulazone.domain.product.service.ProductDomainService;
+
+@RequiredArgsConstructor
+@Component
+public class ProductCreatedEventListener {
+
+	private final ProductDomainService productDomainService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ProductCreatedEvent event) {
+		productDomainService.saveProductToEs(event.product());
+	}
+}

--- a/src/main/java/nbc/chillguys/nebulazone/application/product/service/ProductAdminService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/product/service/ProductAdminService.java
@@ -96,7 +96,6 @@ public class ProductAdminService {
 			auctionRedisService.updateAuctionProductImages(updatedProduct.getAuctionId(), productImageUrs);
 		}
 
-		// productDomainService.saveProductToEs(updatedProduct);
 		eventPublisher.publishEvent(new ProductUpdatedEvent(updatedProduct));
 
 		return ProductResponse.from(updatedProduct);

--- a/src/main/java/nbc/chillguys/nebulazone/application/product/service/ProductService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/application/product/service/ProductService.java
@@ -36,6 +36,7 @@ import nbc.chillguys.nebulazone.domain.product.entity.Product;
 import nbc.chillguys.nebulazone.domain.product.entity.ProductEndTime;
 import nbc.chillguys.nebulazone.domain.product.entity.ProductTxMethod;
 import nbc.chillguys.nebulazone.domain.product.event.ChangeToAuctionTypeEvent;
+import nbc.chillguys.nebulazone.domain.product.event.ProductCreatedEvent;
 import nbc.chillguys.nebulazone.domain.product.event.ProductDeletedEvent;
 import nbc.chillguys.nebulazone.domain.product.event.ProductPurchasedEvent;
 import nbc.chillguys.nebulazone.domain.product.event.ProductUpdatedEvent;
@@ -83,7 +84,7 @@ public class ProductService {
 			createdProduct.updateAuctionId(createdAuction.getId());
 		}
 
-		productDomainService.saveProductToEs(createdProduct);
+		eventPublisher.publishEvent(new ProductCreatedEvent(createdProduct));
 
 		return ProductResponse.from(createdProduct, productEndTime);
 	}
@@ -207,7 +208,7 @@ public class ProductService {
 			auctionRedisService.updateAuctionProductImages(updatedProduct.getAuctionId(), productImageUrs);
 		}
 
-		productDomainService.saveProductToEs(updatedProduct);
+		eventPublisher.publishEvent(new ProductUpdatedEvent(updatedProduct));
 
 		return ProductResponse.from(updatedProduct);
 	}

--- a/src/main/java/nbc/chillguys/nebulazone/domain/auction/service/AuctionAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/auction/service/AuctionAdminDomainService.java
@@ -46,11 +46,10 @@ public class AuctionAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void updateAuction(Long auctionId, AuctionAdminUpdateCommand command) {
+	public Product updateAuction(Long auctionId, AuctionAdminUpdateCommand command) {
 		Auction auction = findByAuctionById(auctionId);
 		auction.update(command.startPrice(), command.currentPrice(), command.endTime(), command.isWon());
-		Product product = auction.getProduct();
-		productDomainService.saveProductToEs(product);
+		return auction.getProduct();
 	}
 
 	/**
@@ -64,8 +63,7 @@ public class AuctionAdminDomainService {
 	@Transactional
 	public void deleteAuction(Long auctionId) {
 		Auction auction = findByAuctionById(auctionId);
-		auction.delete(); // 소프트 딜리트: deleted=true, deletedAt=now
-		productDomainService.deleteProductFromEs(auction.getProduct().getId());
+		auction.delete();
 	}
 
 	/**

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/event/CreatePostEvent.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/event/CreatePostEvent.java
@@ -1,0 +1,8 @@
+package nbc.chillguys.nebulazone.domain.post.event;
+
+import nbc.chillguys.nebulazone.domain.post.entity.Post;
+
+public record CreatePostEvent(
+	Post post
+) {
+}

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
-import nbc.chillguys.nebulazone.domain.post.event.UpdatePostEvent;
+import nbc.chillguys.nebulazone.domain.post.event.CreatePostEvent;
 import nbc.chillguys.nebulazone.domain.post.service.PostDomainService;
 
 @RequiredArgsConstructor
@@ -17,7 +17,7 @@ public class CreatePostEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleUpdatePost(UpdatePostEvent event) {
+	public void handleUpdatePost(CreatePostEvent event) {
 		postDomainService.savePostToEs(event.post());
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
@@ -17,7 +17,7 @@ public class CreatePostEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleUpdatePost(CreatePostEvent event) {
+	public void handleSavePost(CreatePostEvent event) {
 		postDomainService.savePostToEs(event.post());
 	}
 }

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/listener/CreatePostEventListener.java
@@ -1,0 +1,23 @@
+package nbc.chillguys.nebulazone.domain.post.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import nbc.chillguys.nebulazone.domain.post.event.UpdatePostEvent;
+import nbc.chillguys.nebulazone.domain.post.service.PostDomainService;
+
+@RequiredArgsConstructor
+@Component
+public class CreatePostEventListener {
+
+	private final PostDomainService postDomainService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleUpdatePost(UpdatePostEvent event) {
+		postDomainService.savePostToEs(event.post());
+	}
+}

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
@@ -17,7 +17,6 @@ import nbc.chillguys.nebulazone.domain.post.exception.PostErrorCode;
 import nbc.chillguys.nebulazone.domain.post.exception.PostException;
 import nbc.chillguys.nebulazone.domain.post.repository.PostEsRepository;
 import nbc.chillguys.nebulazone.domain.post.repository.PostRepository;
-import nbc.chillguys.nebulazone.domain.post.vo.PostDocument;
 
 @Service
 @RequiredArgsConstructor
@@ -54,8 +53,6 @@ public class PostAdminDomainService {
 		Post post = findActivePost(command.postId());
 
 		post.update(command.title(), command.content());
-		savePostToEs(post);
-
 		return post;
 	}
 
@@ -132,18 +129,6 @@ public class PostAdminDomainService {
 	}
 
 	/**
-	 * 활성 상태의 게시글을 ID로 조회합니다.
-	 *
-	 * @param postId 게시글 ID
-	 * @return 게시글 엔티티
-	 * @author 정석현
-	 */
-	public Post findMyActivePost(Long postId) {
-
-		return findActivePost(postId);
-	}
-
-	/**
 	 * 삭제된 게시글을 ID로 조회합니다.
 	 *
 	 * @param postId 게시글 ID
@@ -153,28 +138,6 @@ public class PostAdminDomainService {
 	public Post findDeletedPost(Long postId) {
 		return postRepository.findDeletedPostById(postId)
 			.orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-	}
-
-	/**
-	 * 게시글을 ES(검색엔진)에 저장(업데이트)합니다.
-	 *
-	 * @param post 게시글 엔티티
-	 * @author 정석현
-	 */
-	@Transactional
-	public void savePostToEs(Post post) {
-		postEsRepository.save(PostDocument.from(post));
-	}
-
-	/**
-	 * 게시글을 ES(검색엔진)에서 삭제합니다.
-	 *
-	 * @param postId 게시글 ID
-	 * @author 정석현
-	 */
-	@Transactional
-	public void deletePostFromEs(Long postId) {
-		postEsRepository.deleteById(postId);
 	}
 
 	/**

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
@@ -15,7 +15,6 @@ import nbc.chillguys.nebulazone.domain.post.entity.Post;
 import nbc.chillguys.nebulazone.domain.post.entity.PostType;
 import nbc.chillguys.nebulazone.domain.post.exception.PostErrorCode;
 import nbc.chillguys.nebulazone.domain.post.exception.PostException;
-import nbc.chillguys.nebulazone.domain.post.repository.PostEsRepository;
 import nbc.chillguys.nebulazone.domain.post.repository.PostRepository;
 
 @Service
@@ -23,7 +22,6 @@ import nbc.chillguys.nebulazone.domain.post.repository.PostRepository;
 public class PostAdminDomainService {
 
 	private final PostRepository postRepository;
-	private final PostEsRepository postEsRepository;
 
 	/**
 	 * 검색 조건과 페이징 정보에 따라 게시글 목록을 조회합니다.

--- a/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/post/service/PostAdminDomainService.java
@@ -81,10 +81,10 @@ public class PostAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void updatePostType(Long postId, PostType type) {
+	public Post updatePostType(Long postId, PostType type) {
 		Post post = findActivePost(postId);
 		post.updateType(type);
-		savePostToEs(post);
+		return post;
 	}
 
 	/**
@@ -96,13 +96,13 @@ public class PostAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void deletePost(Long postId) {
+	public Long deletePost(Long postId) {
 		Post post = findDeletedPost(postId);
 
 		post.validatePostOwner(postId);
 
 		post.delete();
-		deletePostFromEs(postId);
+		return post.getId();
 	}
 
 	/**
@@ -113,10 +113,10 @@ public class PostAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void restorePost(Long postId) {
+	public Post restorePost(Long postId) {
 		Post post = findActivePost(postId);
 		post.restore();
-		savePostToEs(post);
+		return post;
 	}
 
 	/**

--- a/src/main/java/nbc/chillguys/nebulazone/domain/product/event/ProductCreatedEvent.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/product/event/ProductCreatedEvent.java
@@ -1,0 +1,8 @@
+package nbc.chillguys.nebulazone.domain.product.event;
+
+import nbc.chillguys.nebulazone.domain.product.entity.Product;
+
+public record ProductCreatedEvent(
+	Product product
+) {
+}

--- a/src/main/java/nbc/chillguys/nebulazone/domain/product/service/ProductAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/product/service/ProductAdminDomainService.java
@@ -21,7 +21,6 @@ import nbc.chillguys.nebulazone.domain.product.repository.ProductRepository;
 public class ProductAdminDomainService {
 
 	private final ProductRepository productRepository;
-	private final ProductDomainService productDomainService;
 
 	/**
 	 * 검색 조건과 페이징 정보에 따라 상품 목록을 조회합니다.

--- a/src/main/java/nbc/chillguys/nebulazone/domain/product/service/ProductAdminDomainService.java
+++ b/src/main/java/nbc/chillguys/nebulazone/domain/product/service/ProductAdminDomainService.java
@@ -60,7 +60,7 @@ public class ProductAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void updateProduct(Long productId, ProductAdminUpdateRequest request) {
+	public Product updateProduct(Long productId, ProductAdminUpdateRequest request) {
 
 		Product product = findByIdWithJoin(productId);
 
@@ -75,7 +75,8 @@ public class ProductAdminDomainService {
 		} else if (request.price() != null && !request.price().equals(product.getPrice())) {
 			product.changePrice(request.price());
 		}
-		productDomainService.saveProductToEs(product);
+
+		return product;
 	}
 
 	/**
@@ -86,10 +87,10 @@ public class ProductAdminDomainService {
 	 * @author 정석현
 	 */
 	@Transactional
-	public void deleteProduct(Long productId) {
+	public Long deleteProduct(Long productId) {
 		Product product = findByIdWithJoin(productId);
 		product.delete();
-		productDomainService.deleteProductFromEs(productId);
+		return product.getId();
 	}
 
 	/**
@@ -99,10 +100,10 @@ public class ProductAdminDomainService {
 	 * @param productId 복원할 상품 ID
 	 * @author 정석현
 	 */
-	public void restoreProduct(Long productId) {
+	public Product restoreProduct(Long productId) {
 		Product product = findByIdWithJoin(productId);
 		product.restore();
-		productDomainService.saveProductToEs(product);
+		return product;
 	}
 
 	/**

--- a/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
+++ b/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
@@ -107,7 +107,6 @@ class AuctionRedisServiceTest {
 	private AuctionVo wonAuctionVo;
 	private BidVo bidVo;
 	private CreateRedisAuctionDto createRedisAuctionDto;
-	private Product product;
 	private Auction auction;
 
 	@BeforeEach
@@ -140,7 +139,7 @@ class AuctionRedisServiceTest {
 			BidStatus.WON.name(),
 			LocalDateTime.now());
 
-		product = Product.builder()
+		Product product = Product.builder()
 			.name("테스트 상품")
 			.description("테스트 상품 설명")
 			.price(100000L)
@@ -166,6 +165,7 @@ class AuctionRedisServiceTest {
 
 		@DisplayName("레디스 경매 생성 성공")
 		@Test
+		@SuppressWarnings("unchecked")
 		void success_createAuction() {
 			// given
 			given(redisTemplate.opsForHash()).willReturn(hashOperations);

--- a/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
+++ b/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
@@ -403,7 +403,7 @@ class AuctionRedisServiceTest {
 
 		@DisplayName("정렬 기반 경매 조회 성공 - 마감 임박순")
 		@Test
-		void success_findAuctionsBySortType_closing() throws Exception {
+		void success_findAuctionsBySortType_closing() {
 			// given
 			given(redisTemplate.opsForValue()).willReturn(valueOperations);
 			given(valueOperations.get("auction:sorted:CLOSING"))
@@ -425,7 +425,7 @@ class AuctionRedisServiceTest {
 
 		@DisplayName("정렬 기반 경매 조회 성공 - 인기순(입찰개수)")
 		@Test
-		void success_findAuctionsBySortType_popular() throws Exception {
+		void success_findAuctionsBySortType_popular() {
 			// given
 			given(redisTemplate.opsForValue()).willReturn(valueOperations);
 			given(valueOperations.get("auction:sorted:POPULAR"))

--- a/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
+++ b/src/test/java/nbc/chillguys/nebulazone/application/auction/service/AuctionRedisServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -68,6 +69,9 @@ class AuctionRedisServiceTest {
 
 	@Mock
 	private ZSetOperations<String, Object> zSetOperations;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@Mock
 	private ObjectMapper objectMapper;
@@ -223,6 +227,8 @@ class AuctionRedisServiceTest {
 			given(zSetOperations.remove(anyString(), any())).willReturn(1L);
 			given(redisTemplate.delete(anyString())).willReturn(true);
 			willDoNothing().given(redisMessagePublisher).publishAuctionUpdate(anyLong(), anyString(), any());
+			willDoNothing().given(eventPublisher).publishEvent(anyLong());
+			willDoNothing().given(eventPublisher).publishEvent(anyLong());
 
 			// when
 			EndAuctionResponse result = auctionRedisService.manualEndAuction(auctionId, user, request);
@@ -349,10 +355,10 @@ class AuctionRedisServiceTest {
 			given(zSetOperations.range(anyString(), anyLong(), anyLong())).willReturn(Set.of());
 			given(userDomainService.findActiveUserByIds(anyList())).willReturn(List.of());
 			willDoNothing().given(bidDomainService).createAllBid(any(), anyList(), anyMap());
-			willDoNothing().given(productDomainService).deleteProductFromEs(anyLong());
 			given(zSetOperations.remove(anyString(), any())).willReturn(1L);
 			given(redisTemplate.delete(anyString())).willReturn(true);
 			willDoNothing().given(redisMessagePublisher).publishAuctionUpdate(anyLong(), anyString(), any());
+			willDoNothing().given(eventPublisher).publishEvent(anyLong());
 
 			// when
 			DeleteAuctionResponse result = auctionRedisService.deleteAuction(auctionId, user);

--- a/src/test/java/nbc/chillguys/nebulazone/application/product/service/ProductServiceTest.java
+++ b/src/test/java/nbc/chillguys/nebulazone/application/product/service/ProductServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,8 @@ import nbc.chillguys.nebulazone.domain.product.dto.ProductSearchCommand;
 import nbc.chillguys.nebulazone.domain.product.entity.Product;
 import nbc.chillguys.nebulazone.domain.product.entity.ProductEndTime;
 import nbc.chillguys.nebulazone.domain.product.entity.ProductTxMethod;
+import nbc.chillguys.nebulazone.domain.product.event.ProductCreatedEvent;
+import nbc.chillguys.nebulazone.domain.product.event.ProductUpdatedEvent;
 import nbc.chillguys.nebulazone.domain.product.service.ProductDomainService;
 import nbc.chillguys.nebulazone.domain.product.vo.ProductDocument;
 import nbc.chillguys.nebulazone.domain.user.entity.Address;
@@ -66,6 +69,9 @@ class ProductServiceTest {
 
 	@Mock
 	private GcsClient gcsClient;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@InjectMocks
 	private ProductService productService;
@@ -217,6 +223,7 @@ class ProductServiceTest {
 			given(productDomainService.createProduct(any(ProductCreateCommand.class))).willReturn(auctionProduct);
 			given(auctionDomainService.createAuction(any(AuctionCreateCommand.class))).willReturn(auction);
 			willDoNothing().given(auctionRedisService).createAuction(any(CreateRedisAuctionDto.class));
+			willDoNothing().given(eventPublisher).publishEvent(any(ProductCreatedEvent.class));
 
 			// when
 			ProductResponse result = productService.createProduct(user, catalogId, request);
@@ -247,6 +254,7 @@ class ProductServiceTest {
 
 			given(catalogDomainService.getCatalogById(catalogId)).willReturn(catalog);
 			given(productDomainService.createProduct(any(ProductCreateCommand.class))).willReturn(product);
+			willDoNothing().given(eventPublisher).publishEvent(any(ProductCreatedEvent.class));
 
 			// when
 			ProductResponse result = productService.createProduct(user, catalogId, request);
@@ -304,6 +312,7 @@ class ProductServiceTest {
 			given(productDomainService.findActiveProductById(updateProductId)).willReturn(product);
 			given(productDomainService.updateProductImages(any(Product.class), eq(updatedImageUrls), eq(user.getId())))
 				.willReturn(product);
+			willDoNothing().given(eventPublisher).publishEvent(any(ProductUpdatedEvent.class));
 
 			// when
 			ProductResponse result = productService.updateProductImages(updateProductId, newImageFiles, user,


### PR DESCRIPTION
어드민 경매, 상품, 게시글 및 일반 경매, 상품, 게시글에서 ES 데이터 삭제, 생성, 수정 처리를 비동기로 처리하도록 수정

단, 자동낙찰, 수동 낙찰 시에 구매 관련된 비동기 처리는 낙찰, 유찰 처리에 따라 별도의 거래내역이 생성되야 하므로
해당 로직들만 직접 ES관련 메서드를 직접 호출하여 처리하도록 유지,

현재 생성된 구매 EventListner를 적용할 경우 거래내역을 생성하는 로직을 대량 수정하고 별도의 이벤트 리스너가 각각 필요하여 대공사가 필요하다고 판단됨.